### PR TITLE
Make nrdb download strip typesetting characters

### DIFF
--- a/src/nr_data/download.clj
+++ b/src/nr_data/download.clj
@@ -261,17 +261,13 @@
               target-str))]
     (let [raw-cards (download-fn (-> tables :card :path))
           raw-cards (map #(assoc % :title (strip-typesetting-chars (:title %))) raw-cards)
-          ;;_ (println (first raw-cards))
           card-stub (fn [_] raw-cards)
           cards (->> (fetch-data card-stub (:card tables) add-card-fields)
                      (add-stripped-card-text)
                      (cards->map :id))
-          ;;_ (println (first (filter #(= (first %) "ken-express-tenma-disappeared-clone") cards)))
           raw-set-cards (fetch-data card-stub
                                     (:set-card tables)
                                     (partial add-set-card-fields cards (cards->map sets)))]
-      ;;(println (first cards))
-      ;;(java.lang.System/exit 0)
     (println "Saving edn/cards")
     (doseq [[path card] cards
             :let [path (str "edn/cards/" path ".edn")]]


### PR DESCRIPTION
Basically I don't think it should ever be required to type unicode characters to play our game or use our deckbuilder.
Accents on characters are forgivable, but these fancy quotes are both extremely hard to distinguish and next to impossible to type.
Good luck remembering which of these two apostrophes you need to search for tomorrow's headline on netrunnerdb, and which one you need for aesop's pawnshop: `ʼ ’`
If they ever get goofier with these, it's easy enough to just add to the map.